### PR TITLE
Fix compile errors on Unity 2019.3.0f5

### DIFF
--- a/Assets/AssetDatabaseTalk/Scripts/LibraryMetadataColoriser.cs
+++ b/Assets/AssetDatabaseTalk/Scripts/LibraryMetadataColoriser.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -19,7 +19,7 @@ public class LibraryMetadataColoriser : MonoBehaviour
 			Object currentObject = Selection.activeObject;
 			
 			string guid;
-#if UNITY_2018_2
+#if UNITY_2018_2_OR_NEWER
 			long localID;
 #else
 			int localID;

--- a/Assets/AssetDatabaseTalk/Scripts/OpenCurrentMetatDataFile.cs
+++ b/Assets/AssetDatabaseTalk/Scripts/OpenCurrentMetatDataFile.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 using UnityEngine;
 
 public class OpenCurrentMetatDataFile : MonoBehaviour 
@@ -8,8 +8,8 @@ public class OpenCurrentMetatDataFile : MonoBehaviour
 		Object currentObject = Selection.activeObject;
 		string currentObjectPath = AssetDatabase.GetAssetPath(currentObject);
 		string guid;
-		
-#if UNITY_2018_2
+
+#if UNITY_2018_2_OR_NEWER
 		long localID;
 #else
 		int localID;

--- a/Assets/AssetDatabaseTalk/Scripts/TextToCurrentAssetInfo.cs
+++ b/Assets/AssetDatabaseTalk/Scripts/TextToCurrentAssetInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UI;
@@ -94,7 +94,7 @@ public class TextToCurrentAssetInfo : MonoBehaviour
 		string result = template;
 
 		string guid;
-#if UNITY_2018_2
+#if UNITY_2018_2_OR_NEWER
 		long localID;
 #else
 		int localID;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,3 +1,26 @@
 {
-  "dependencies": {}
+  "dependencies": {
+    "com.unity.2d.sprite": "1.0.0",
+    "com.unity.2d.tilemap": "1.0.0",
+    "com.unity.collab-proxy": "1.2.16",
+    "com.unity.ide.rider": "1.1.4",
+    "com.unity.ide.vscode": "1.1.3",
+    "com.unity.multiplayer-hlapi": "1.0.4",
+    "com.unity.test-framework": "1.1.9",
+    "com.unity.timeline": "1.2.9",
+    "com.unity.ugui": "1.0.0",
+    "com.unity.xr.legacyinputhelpers": "1.3.8",
+    "com.unity.modules.androidjni": "1.0.0",
+    "com.unity.modules.animation": "1.0.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.director": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.particlesystem": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
+    "com.unity.modules.ui": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
+    "com.unity.modules.video": "1.0.0",
+    "com.unity.modules.vr": "1.0.0",
+    "com.unity.modules.xr": "1.0.0"
+  }
 }


### PR DESCRIPTION
- Replace instances of "UNITY_2018_2" with "UNITY_2018_2_OR_NEWER"
- Add necessary dependencies to manifest.json

This PR does not replace uses of obsolete APIs that are not compiler errors.